### PR TITLE
Added run conditions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ categories = ["game-development"]
 keywords = ["gamedev", "bevy-plugin", "input"]
 
 [features]
-default = ["derive"]
+default = ["derive", "conditions"]
 derive = ["dep:bevy_actify_derive"]
+conditions = []
 
 [dependencies]
 bevy = { version = "0.15", default-features = false }

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -1,6 +1,30 @@
-use crate::{InputAction, InputActionState};
+use crate::{InputAction, InputActionReader, InputActionState, InputActionStatus};
 
 /// Returns `true` if the input action [`A`] is active.
 pub fn input_action_active<A: InputAction>(action: InputActionState<A>) -> bool {
     action.is_active()
+}
+
+/// Returns `true` if the input action [`A`] has just started.
+pub fn input_action_started<A: InputAction>(mut action: InputActionReader<A>) -> bool {
+    action
+        .read()
+        .last()
+        .map_or(false, |a| matches!(a, InputActionStatus::Started(_)))
+}
+
+/// Returns `true` if the input action [`A`] has just updated.
+pub fn input_action_updated<A: InputAction>(mut action: InputActionReader<A>) -> bool {
+    action
+        .read()
+        .last()
+        .map_or(false, |a| matches!(a, InputActionStatus::Updated(_)))
+}
+
+/// Returns `true` if the input action [`A`] has just stopped.
+pub fn input_action_stopped<A: InputAction>(mut action: InputActionReader<A>) -> bool {
+    action
+        .read()
+        .last()
+        .map_or(false, |a| matches!(a, InputActionStatus::Stopped))
 }

--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -1,0 +1,6 @@
+use crate::{InputAction, InputActionState};
+
+/// Returns `true` if the input action [`A`] is active.
+pub fn input_action_active<A: InputAction>(action: InputActionState<A>) -> bool {
+    action.is_active()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! SPDX-License-Identifier: MIT OR Apache-2.0
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "conditions")]
+pub mod conditions;
+
 #[cfg(feature = "derive")]
 pub use bevy_actify_derive::InputAction;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,11 @@ pub mod conditions;
 #[cfg(feature = "derive")]
 pub use bevy_actify_derive::InputAction;
 
+#[cfg(feature = "conditions")]
+pub use conditions::{
+    input_action_active, input_action_started, input_action_stopped, input_action_updated,
+};
+
 use std::marker::PhantomData;
 
 use bevy::{


### PR DESCRIPTION
Added run conditions for input action status and status updated:

* `input_action_active`: returns `true` while the input action is active;
* `input_action_started`: returns `true` when the input action has just started;
* `input_action_updated`: returns `true` when the input action has just updated;
* `input_action_stopped`: returns `true` when the input action has jus stopped.